### PR TITLE
Refactor module to use filter chains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=builder /usr/local/nginx /usr/local/nginx
 COPY --from=builder /opt/nginx-car-range/target/debug/libnginx_car_range.so /usr/local/lib/libnginx_car_range.so
 COPY --from=builder /opt/nginx-car-range/car /usr/local/bin/car
 
-COPY fixture.car /var/www/html/fixture.car
+COPY fixture.car /usr/local/nginx/html/fixture.car
 COPY config/nginx.conf /etc/nginx/nginx.conf
 COPY ci.sh /ci.sh
 RUN chmod u+rwx /ci.sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,11 @@ pub static mut ngx_module_names: [*const c_char; 2] =
 
 #[no_mangle]
 pub static mut ngx_module_order: [*const c_char; 3] = [
-    "ngx_http_copy_filter_module\0".as_ptr() as *const c_char,
     "car_range\0".as_ptr() as *const c_char,
+    "ngx_http_copy_filter_module\0".as_ptr() as *const c_char,
     ptr::null(),
 ];
 
 #[no_mangle]
 pub static mut ngx_module_type: [*const c_char; 2] =
-    ["HTTP_INIT_FILTER\0".as_ptr() as *const c_char, ptr::null()];
+    ["HTTP_AUX_FILTER\0".as_ptr() as *const c_char, ptr::null()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,7 @@ pub static mut ngx_module_names: [*const c_char; 2] =
 
 #[no_mangle]
 pub static mut ngx_module_order: [*const c_char; 1] = [ptr::null()];
+
+#[no_mangle]
+pub static mut ngx_module_type: [*const c_char; 2] =
+    ["HTTP_FILTER\0".as_ptr() as *const c_char, ptr::null()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,4 +32,4 @@ pub static mut ngx_module_order: [*const c_char; 3] = [
 
 #[no_mangle]
 pub static mut ngx_module_type: [*const c_char; 2] =
-    ["HTTP_FILTER\0".as_ptr() as *const c_char, ptr::null()];
+    ["HTTP_INIT_FILTER\0".as_ptr() as *const c_char, ptr::null()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,11 @@ pub static mut ngx_module_names: [*const c_char; 2] =
     ["car_range\0".as_ptr() as *const c_char, ptr::null()];
 
 #[no_mangle]
-pub static mut ngx_module_order: [*const c_char; 1] = [ptr::null()];
+pub static mut ngx_module_order: [*const c_char; 3] = [
+    "output_buffers\0".as_ptr() as *const c_char,
+    "car_range\0".as_ptr() as *const c_char,
+    ptr::null(),
+];
 
 #[no_mangle]
 pub static mut ngx_module_type: [*const c_char; 2] =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod bindings;
+mod pool;
 // mod car_reader;
 pub mod module;
 mod request;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,12 +24,9 @@ pub static mut ngx_module_names: [*const c_char; 2] =
     ["car_range\0".as_ptr() as *const c_char, ptr::null()];
 
 #[no_mangle]
-pub static mut ngx_module_order: [*const c_char; 3] = [
-    "output_buffers\0".as_ptr() as *const c_char,
-    "car_range\0".as_ptr() as *const c_char,
-    ptr::null(),
-];
+pub static mut ngx_module_order: [*const c_char; 2] =
+    ["car_range\0".as_ptr() as *const c_char, ptr::null()];
 
 #[no_mangle]
 pub static mut ngx_module_type: [*const c_char; 2] =
-    ["HTTP_FILTER\0".as_ptr() as *const c_char, ptr::null()];
+    ["HTTP_AUX_FILTER\0".as_ptr() as *const c_char, ptr::null()];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,12 @@ pub static mut ngx_module_names: [*const c_char; 2] =
     ["car_range\0".as_ptr() as *const c_char, ptr::null()];
 
 #[no_mangle]
-pub static mut ngx_module_order: [*const c_char; 2] =
-    ["car_range\0".as_ptr() as *const c_char, ptr::null()];
+pub static mut ngx_module_order: [*const c_char; 3] = [
+    "ngx_http_copy_filter_module\0".as_ptr() as *const c_char,
+    "car_range\0".as_ptr() as *const c_char,
+    ptr::null(),
+];
 
 #[no_mangle]
 pub static mut ngx_module_type: [*const c_char; 2] =
-    ["HTTP_AUX_FILTER\0".as_ptr() as *const c_char, ptr::null()];
+    ["HTTP_FILTER\0".as_ptr() as *const c_char, ptr::null()];

--- a/src/module.rs
+++ b/src/module.rs
@@ -39,8 +39,8 @@ static mut ngx_car_range_commands: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("car_range"), /* directive */
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t, /* location context and takes no arguments*/
-        set: Some(ngx_conf_set_flag_slot), /* configuration setup function */
-        conf: 0,                           /* No offset. Only one context is supported. */
+        set: None, /* configuration setup function */
+        conf: 0,   /* No offset. Only one context is supported. */
         offset: 0, /* No offset when storing the module configuration on struct. */
         post: ptr::null_mut(),
     },

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,4 +1,5 @@
 use crate::bindings::*;
+use crate::pool::{Buffer, MemoryBuffer};
 use crate::request::*;
 use std::os::raw::{c_char, c_void};
 use std::ptr;
@@ -141,8 +142,8 @@ extern "C" fn ngx_car_range_body_filter(
     let mut count = 0;
 
     while !cl.is_null() {
-        let buf = unsafe { *(*cl).buf };
-        count += usize::wrapping_sub(buf.last as _, buf.pos as _);
+        let buf = unsafe { MemoryBuffer::from_ngx_buf((*cl).buf) };
+        count += buf.len();
 
         cl = unsafe { (*cl).next };
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -145,6 +145,8 @@ extern "C" fn ngx_car_range_body_filter(
         let buf = unsafe { MemoryBuffer::from_ngx_buf((*cl).buf) };
         count += buf.len();
 
+        ngx_log_debug_http!(req, "car_range buf slice size {}", buf.as_bytes().len());
+
         cl = unsafe { (*cl).next };
     }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -165,8 +165,8 @@ extern "C" fn ngx_car_range_header_filter(r: *mut ngx_http_request_t) -> ngx_int
 // Prepend to filter chain
 #[no_mangle]
 unsafe extern "C" fn ngx_car_range_filter_init(_: *mut ngx_conf_t) -> ngx_int_t {
-    ngx_http_next_header_filter = ngx_http_top_header_filter;
-    ngx_http_top_header_filter = Some(ngx_car_range_header_filter);
+    // ngx_http_next_header_filter = ngx_http_top_header_filter;
+    // ngx_http_top_header_filter = Some(ngx_car_range_header_filter);
 
     return NGX_OK as ngx_int_t;
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -115,13 +115,13 @@ unsafe fn ngx_http_conf_get_module_loc_conf(
 
 #[no_mangle]
 unsafe extern "C" fn ngx_car_range(
-    cf: *mut ngx_conf_t,
+    _cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
     _conf: *mut c_void,
 ) -> *mut c_char {
-    let clcf = ngx_http_conf_get_module_loc_conf(cf, &ngx_http_core_module)
-        as *mut ngx_http_core_loc_conf_t;
-    (*clcf).handler = Some(ngx_car_range_handler);
+    // let clcf = ngx_http_conf_get_module_loc_conf(cf, &ngx_http_core_module)
+    //     as *mut ngx_http_core_loc_conf_t;
+    // (*clcf).handler = Some(ngx_car_range_handler);
 
     ptr::null_mut()
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -31,6 +31,7 @@ macro_rules! ngx_log_debug_http {
     }
 }
 
+#[no_mangle]
 pub static mut ngx_http_next_header_filter: ngx_http_output_header_filter_pt = None;
 
 #[no_mangle]

--- a/src/module.rs
+++ b/src/module.rs
@@ -39,9 +39,9 @@ static mut ngx_car_range_commands: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("car_range"), /* directive */
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t, /* location context and takes no arguments*/
-        set: None, /* configuration setup function */
-        conf: 0,   /* No offset. Only one context is supported. */
-        offset: 0, /* No offset when storing the module configuration on struct. */
+        set: Some(ngx_car_range), /* configuration setup function */
+        conf: 0,                  /* No offset. Only one context is supported. */
+        offset: 0,                /* No offset when storing the module configuration on struct. */
         post: ptr::null_mut(),
     },
     /* command termination */

--- a/src/module.rs
+++ b/src/module.rs
@@ -31,7 +31,7 @@ macro_rules! ngx_log_debug_http {
     }
 }
 
-static mut ngx_http_next_header_filter: ngx_http_output_header_filter_pt = None;
+pub static mut ngx_http_next_header_filter: ngx_http_output_header_filter_pt = None;
 
 #[no_mangle]
 static mut ngx_car_range_commands: [ngx_command_t; 2] = [
@@ -148,9 +148,9 @@ extern "C" fn ngx_car_range_header_filter(r: *mut ngx_http_request_t) -> ngx_int
         };
     }
 
-    if !req.accept_car() {
-        bail!();
-    }
+    // if !req.accept_car() {
+    //     bail!();
+    // }
     // Check if range request
     // let range = match req.range() {
     //     Some(range_val) => range_val,

--- a/src/module.rs
+++ b/src/module.rs
@@ -165,8 +165,8 @@ extern "C" fn ngx_car_range_header_filter(r: *mut ngx_http_request_t) -> ngx_int
 // Prepend to filter chain
 #[no_mangle]
 unsafe extern "C" fn ngx_car_range_filter_init(_: *mut ngx_conf_t) -> ngx_int_t {
-    // ngx_http_next_header_filter = ngx_http_top_header_filter;
-    // ngx_http_top_header_filter = Some(ngx_car_range_header_filter);
+    ngx_http_next_header_filter = ngx_http_top_header_filter;
+    ngx_http_top_header_filter = Some(ngx_car_range_header_filter);
 
     return NGX_OK as ngx_int_t;
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -133,6 +133,22 @@ extern "C" fn ngx_car_range_body_filter(
         };
     }
 
+    if !req.accept_car() {
+        bail!();
+    }
+
+    let mut cl = body;
+    let mut count = 0;
+
+    while !cl.is_null() {
+        let buf = unsafe { *(*cl).buf };
+        count += usize::wrapping_sub(buf.last as _, buf.pos as _);
+
+        cl = unsafe { (*cl).next };
+    }
+
+    ngx_log_debug_http!(req, "car_range body size {}", count);
+
     bail!()
 }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -38,8 +38,8 @@ static mut ngx_car_range_commands: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("car_range"), /* directive */
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS) as ngx_uint_t, /* location context and takes no arguments*/
-        set: None, /* configuration setup function */
-        conf: 0,   /* No offset. Only one context is supported. */
+        set: Some(ngx_conf_set_flag_slot), /* configuration setup function */
+        conf: 0,                           /* No offset. Only one context is supported. */
         offset: 0, /* No offset when storing the module configuration on struct. */
         post: ptr::null_mut(),
     },
@@ -162,11 +162,10 @@ extern "C" fn ngx_car_range_header_filter(r: *mut ngx_http_request_t) -> ngx_int
 }
 
 // Prepend to filter chain
-extern "C" fn ngx_car_range_filter_init(_: *mut ngx_conf_t) -> ngx_int_t {
-    unsafe {
-        ngx_http_next_header_filter = ngx_http_top_header_filter;
-        ngx_http_top_header_filter = Some(ngx_car_range_header_filter);
-    }
+#[no_mangle]
+unsafe extern "C" fn ngx_car_range_filter_init(_: *mut ngx_conf_t) -> ngx_int_t {
+    ngx_http_next_header_filter = ngx_http_top_header_filter;
+    ngx_http_top_header_filter = Some(ngx_car_range_header_filter);
 
     return NGX_OK as ngx_int_t;
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,14 @@
+use crate::bindings::*;
+
+pub struct Pool(*mut ngx_pool_t);
+
+impl Pool {
+    pub unsafe fn from_ngx_pool(pool: *mut ngx_pool_t) -> Pool {
+        assert!(!pool.is_null());
+        Pool(pool)
+    }
+
+    pub fn alloc(&mut self, size: usize) -> *mut std::os::raw::c_void {
+        unsafe { ngx_palloc(self.0, size) }
+    }
+}

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,4 +1,6 @@
 use crate::bindings::*;
+use std::os::raw::c_void;
+use std::{mem, ptr};
 
 pub struct Pool(*mut ngx_pool_t);
 
@@ -8,7 +10,34 @@ impl Pool {
         Pool(pool)
     }
 
-    pub fn alloc(&mut self, size: usize) -> *mut std::os::raw::c_void {
+    pub fn alloc(&mut self, size: usize) -> *mut c_void {
         unsafe { ngx_palloc(self.0, size) }
     }
+
+    unsafe fn add_cleanup_for_value<T>(&mut self, value: *mut T) -> Result<(), ()> {
+        let cln = ngx_pool_cleanup_add(self.0, 0);
+        if cln.is_null() {
+            return Err(());
+        }
+        (*cln).handler = Some(cleanup_type::<T>);
+        (*cln).data = value as *mut c_void;
+
+        Ok(())
+    }
+
+    pub fn allocate<T>(&mut self, value: T) -> *mut T {
+        unsafe {
+            let p = self.alloc(mem::size_of::<T>()) as *mut T;
+            ptr::write(p, value);
+            if self.add_cleanup_for_value(p).is_err() {
+                ptr::drop_in_place(p);
+                return ptr::null_mut();
+            };
+            p
+        }
+    }
+}
+
+unsafe extern "C" fn cleanup_type<T>(data: *mut c_void) {
+    ptr::drop_in_place(data as *mut T);
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,5 @@
 use crate::bindings::*;
+use crate::pool::Pool;
 use std::borrow::Cow;
 use std::ops::Bound;
 
@@ -48,6 +49,12 @@ impl Request {
 
     pub fn connection(&self) -> *mut ngx_connection_t {
         self.0.connection
+    }
+
+    /// Request pool.
+    pub fn pool(&self) -> Pool {
+        // SAFETY: This request is allocated from `pool`, thus must be a valid pool.
+        unsafe { Pool::from_ngx_pool(self.0.pool) }
     }
 
     pub fn range(&self) -> Option<(Bound<u64>, Bound<u64>)> {


### PR DESCRIPTION
The body filter chain forward the buffers to each other making it easier to filter the CAR response on the fly.